### PR TITLE
Update the standard settings file

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,73 +1,43 @@
 # These settings are synced to GitHub by https://probot.github.io/apps/settings/
+# They can be subclassed in your repo using:
+#   _extends: github-apps-config-next
 
 repository:
-  # See https://developer.github.com/v3/repos/#edit for all available settings.
-
-  # Either `true` to enable issues for this repository, `false` to disable them.
-  has_issues: true
-
-  # Either `true` to enable projects for this repository, or `false` to disable them.
-  # If projects are disabled for the organization, passing `true` will cause an API error.
-  has_projects: false
-
-  # Either `true` to enable the wiki for this repository, `false` to disable it.
-  has_wiki: false
-
-  # Either `true` to enable downloads for this repository, `false` to disable them.
-  has_downloads: true
-
-  # Updates the default branch for this repository.
+  # Default branch is the master branch
   default_branch: master
-
-  # Either `true` to allow squash-merging pull requests, or `false` to prevent
-  # squash-merging.
+  # Allow users to pick what kind of merging they want per PR
   allow_squash_merge: true
-
-  # Either `true` to allow merging pull requests with a merge commit, or `false`
-  # to prevent merging pull requests with merge commits.
   allow_merge_commit: true
-
-  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
-  # rebase-merging.
   allow_rebase_merge: true
 
-# Define labels that can be assigned to issues and pull requests.
-labels:
-  - name: bug
-    description: Something isn't working.
-    color: 990F3D
-
-  - name: duplicate
-    description: Looks like this issue already exists.
-    color: 262A33
-
-  - name: dependency
-    description: Upgrade all the things.
-    color: 0F5499
-
-  - name: stale
-    description: The issue has not had any recent activity.
-    color: 0D7680
-
-# The GitHub teams that will have access to repositories.
 teams:
+  # The next team is allowed to admin any of our repositories
   - name: next
     permission: admin
-
+  # Customer products collaborators should be alowed to push branches
+  - name: customer-products-collaborators
+    permission: push
+  # All users with 2fa enabled should be able to read our repos
   - name: compliant-users
-    permission: read
+    permission: pull
 
-# This is the most minimal branch protection.
 branches:
+  # Protect the master branch from force pushing
   - name: master
-    # https://developer.github.com/v3/repos/branches/#update-branch-protection
-    # Branch Protection settings. Set to null to disable
     protection:
-      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
-      required_pull_request_reviews: null
-      # Required. Require status checks to pass before merging. Set to null to disable
+      # Don't require status checks by default, this can be enabled when this
+      # is subclassed
       required_status_checks: null
-      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-      enforce_admins: null
-      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
-      restrictions: null
+      # Don't require pull request reviews by default, this can be enabled when
+      # this is subclassed
+      required_pull_request_reviews: null
+      # Require admins to pass the same rules as everyone else, given all
+      # Customer Products engineers are admins
+      enforce_admins: true
+      # Restrict who can push to the master branch. By default any admin can
+      # still push which means any Customer Products engineer can push, but
+      # collaborators will need to get a Customer Products engineer to push or
+      # merge pull requests for them
+      restrictions:
+        users: []
+        teams: []

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ _extends: github-apps-config-next
 repository:
   has_wiki: true
   has_projects: true
+branches:
+  - name: master
+    protection:
+      # Take the base rules but also require 1 approval
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+      # Also require some status checks to pass
+      required_status_checks:
+        contexts:
+          - build-test
+          - "ci/circleci: build"
+          - "ci/circleci: test"
 ```
 
 #### [`stale.yml`](https://github.com/Financial-Times/github-apps-config-next/blob/master/.github/stale.yml)


### PR DESCRIPTION
So that it's less opinionated about things that are repository specific,
like if something has a wiki. And more opinionated about things like
which teams have access to the repository and which branches are
protected. This will enable us to have standardised permissions across
all our repositories so anyone in our group can maintain them.