### PR TITLE
Remove master branch as the default

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -3,8 +3,6 @@
 #   _extends: github-apps-config-next
 
 repository:
-  # Default branch is the master branch
-  default_branch: master
   # Allow users to pick what kind of merging they want per PR
   allow_squash_merge: true
   allow_merge_commit: true


### PR DESCRIPTION
In apps they tend to not use master as their main branch. To avoid
having exceptions for them let's not define a master branch.