### PR TITLE
Delete head branches on merge

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -6,6 +6,7 @@ repository:
   allow_squash_merge: false
   allow_merge_commit: true
   allow_rebase_merge: true
+  delete_branch_on_merge: true
 
 teams:
   # The next team is allowed to admin any of our repositories


### PR DESCRIPTION
This enables the automatic deletion of head branches after a pull request is merged.

Under a repositories settings this enables the "Automatically delete head branches" option.

See https://help.github.com/en/github/administering-a-repository/managing-the-automatic-deletion-of-branches for more information.

I believe this is waiting on https://github.com/probot/settings/issues/134 to be resolved, but should start being applied when the settings app upgrades to the latest @octokit/rest package. It's now a documented parameter in the repository edit and create endpoints, https://developer.github.com/v3/repos/#edit.

Resolves https://github.com/Financial-Times/github-apps-config-next/issues/19.