### PR TITLE
Rename team to customer-products

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -9,7 +9,7 @@ repository:
 
 teams:
   # The next team is allowed to admin any of our repositories
-  - name: next
+  - name: customer-products
     permission: admin
   # Customer products collaborators should be alowed to push branches
   - name: customer-products-collaborators


### PR DESCRIPTION
We've updated the name of our github team. This needs to reflect that.