### PR TITLE
Revert "Delete head branches on merge"

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -6,7 +6,6 @@ repository:
   allow_squash_merge: false
   allow_merge_commit: true
   allow_rebase_merge: true
-  delete_branch_on_merge: true
 
 teams:
   # The next team is allowed to admin any of our repositories


### PR DESCRIPTION
Reverts Financial-Times/github-apps-config-next#20

This is causing the settings not to get applied as it's presence seems to break probot settings. We can re-add it when https://github.com/probot/settings/issues/134 is resolved. 