### PR TITLE
Update CircleCI config to Node v12 docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:12
     steps:
       - checkout
       - run: npx prettier --check "{.circleci,.github,manage-github-apps}/**/*"


### PR DESCRIPTION
Fixes failing CircleCI build: https://circleci.com/gh/Financial-Times/github-apps-config-next/42.

```
$ #!/bin/bash -eo pipefail
npx prettier --check "{.circleci,.github,manage-github-apps}/**/*"
npx: installed 1 in 1.405s
prettier requires at least version 10.13.0 of Node, please upgrade

Exited with code exit status 1
```