### PR TITLE
Use Node v12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:14
+      - image: circleci/node:12
     steps:
       - checkout
       - run: npx prettier --check "{.circleci,.github,manage-github-apps}/**/*"


### PR DESCRIPTION
After starting the upgrade to Node v14, I noticed that Serverless apps can only go as high as v12 because that is the latest Node version available for AWS Lambda.

I then encountered these excellent points raised by Simon Plenderleith https://github.com/Financial-Times/tooling-helpers/issues/60, which is essentially that packages should ensure compatibility with all version of Node on which they can run, which will be dictated by the apps consuming them.

To do this will increase build time as the process is duplicated for two Node versions, triplicated for three Node versions, etc. (example [here](https://github.com/adambraimbridge/asari/blob/d0fc553903e7c7d2e6e796e35f8b5e015eabc672/.circleci/config.yml)). Platforms is currently trying to reduce CI build times so to do this would be undermining all those efforts.

There is no release date yet announced for AWS Lambda v14 (nor its corresponding Docker image), although I’ve been told that Node v12 for Lambda came out about a month after it went into LTS (Node v14 goes into LTS on 27 Oct 2020 so we are looking at ~late Nov 2020).

So all that said, the goal for this current upgrade is to get v12 universally applied to Customer Products repos.