### PR TITLE
CPP-642 migrate from circleci/* to cimg/*

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,14 @@
-version: 2
+version: 2.1
+
+orbs:
+  node: circleci/node@4.6.0
 
 jobs:
   build:
     docker:
-      - image: circleci/node:12
+      - image: cimg/node:12.22
     steps:
       - checkout
-      - run: npx prettier --check "{.circleci,.github,manage-github-apps}/**/*"
-      - run: find manage-github-apps/ -type f -name *.json | xargs -n 1 npx github:Financial-Times/manage-github-apps validate-config --config
+      - node/install-npm:
+          version: "7"
+      - run: find manage-github-apps/ -type f -name "*.json" | xargs -n 1 npm exec -- github:Financial-Times/manage-github-apps validate-config --config


### PR DESCRIPTION
These images will be EOL from Dec 31st, and we should migrate to the modern cimg/* equivalents.