### PR TITLE
CPP-784 Add stricter protections on the main branches

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -52,36 +52,3 @@ branches:
       # Explicitly enforce the default behaviour of disallowing the protected
       # branch to be deleted
       allow_deletions: false
-  # Protect the master branch from force pushing
-  - name: master
-    protection:
-      # Require status checks by default, this can be disabled when this is
-      # subclassed
-      required_status_checks:
-        # Tests must have passed for the latest code instead of any commits on
-        # the branch
-        strict: true
-        # Don't list any checks that must pass by default. This should be
-        # overridden with important checks (e.g., a CircleCI test job) that
-        # should pass before merging.
-        checks: []
-      # Require pull request reviews by default, this can be disabled when this
-      # is subclassed
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      # Require admins to pass the same rules as everyone else, given all
-      # Customer Products engineers are admins
-      enforce_admins: true
-      # Restrict who can push to the master branch. By default any admin can
-      # still push which means any Customer Products engineer can push, but
-      # collaborators will need to get a Customer Products engineer to push or
-      # merge pull requests for them
-      restrictions:
-        users: []
-        teams: []
-      # Explicitly enforce the default behaviour of disallowing force pushes to
-      # a protected branch
-      allow_force_pushes: false
-      # Explicitly enforce the default behaviour of disallowing the protected
-      # branch to be deleted
-      allow_deletions: false

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -22,12 +22,20 @@ branches:
   # Protect the main branch from force pushing
   - name: main
     protection:
-      # Don't require status checks by default, this can be enabled when this
+      # Require status checks by default, this can be disabled when this is
+      # subclassed
+      required_status_checks:
+        # Tests must have passed for the latest code instead of any commits on
+        # the branch
+        strict: true
+        # Don't list any checks that must pass by default. This should be
+        # overridden with important checks (e.g., a CircleCI test job) that
+        # should pass before merging.
+        checks: []
+      # Require pull request reviews by default, this can be disabled when this
       # is subclassed
-      required_status_checks: null
-      # Don't require pull request reviews by default, this can be enabled when
-      # this is subclassed
-      required_pull_request_reviews: null
+      required_pull_request_reviews:
+        required_approving_review_count: 1
       # Require admins to pass the same rules as everyone else, given all
       # Customer Products engineers are admins
       enforce_admins: true
@@ -38,15 +46,29 @@ branches:
       restrictions:
         users: []
         teams: []
+      # Explicitly enforce the default behaviour of disallowing force pushes to
+      # a protected branch
+      allow_force_pushes: false
+      # Explicitly enforce the default behaviour of disallowing the protected
+      # branch to be deleted
+      allow_deletions: false
   # Protect the master branch from force pushing
   - name: master
     protection:
-      # Don't require status checks by default, this can be enabled when this
+      # Require status checks by default, this can be disabled when this is
+      # subclassed
+      required_status_checks:
+        # Tests must have passed for the latest code instead of any commits on
+        # the branch
+        strict: true
+        # Don't list any checks that must pass by default. This should be
+        # overridden with important checks (e.g., a CircleCI test job) that
+        # should pass before merging.
+        checks: []
+      # Require pull request reviews by default, this can be disabled when this
       # is subclassed
-      required_status_checks: null
-      # Don't require pull request reviews by default, this can be enabled when
-      # this is subclassed
-      required_pull_request_reviews: null
+      required_pull_request_reviews:
+        required_approving_review_count: 1
       # Require admins to pass the same rules as everyone else, given all
       # Customer Products engineers are admins
       enforce_admins: true
@@ -57,3 +79,9 @@ branches:
       restrictions:
         users: []
         teams: []
+      # Explicitly enforce the default behaviour of disallowing force pushes to
+      # a protected branch
+      allow_force_pushes: false
+      # Explicitly enforce the default behaviour of disallowing the protected
+      # branch to be deleted
+      allow_deletions: false

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ branches:
           - "ci/circleci: test"
 ```
 
+##### Important Note About Status Checks
+
+You **must** include the status checks you expect to pass in the overriding config, otherwise no checks will be required to pass before merging. For example, if you expect CircleCI's `test` job to be passing before you'd consider merging a PR branch you might have a simple `.github/settings.yml` file like
+```yaml
+_extends: github-apps-config-next
+branches:
+  - name: main
+    protection:
+      required_status_checks:
+        checks:
+          - "ci/circleci: test"
+```
+Pleasingly, the Probot app will merge the overridden `main` setting with the rest of the inherited settings for `main` via [`deepmerge`](https://github.com/TehShrike/deepmerge), as documented in their [README](https://github.com/probot/settings#inheritance).
+
 #### [`stale.yml`](https://github.com/Financial-Times/github-apps-config-next/blob/main/.github/stale.yml)
 
 These settings are for the ["Stale" GitHub App](https://github.com/probot/stale). It closes abandoned issues and pull requests after a period of inactivity.


### PR DESCRIPTION
Based on a survey of Tech Leads, the following settings are now enabled in every repo by default:
- Require a pull request before merging
- Require status checks to pass before merging
- Include administrators

Additionally, the following settings are now explicitly disabled (just in case):
- Allow force pushes
- Allow deletions

All of these options can, of course, be overridden when subclassing this config.

These changes will prevent accidental commits to main and make it clearer when it is safe to merge code into the main branch.

One issue I've found is that if we don't specify any required status checks then no status checks are required to pass, regardless of whether we set the option to require status checks or not. We can't really assume what status checks are going to be present in general so projects will have to make sure to override the default with the required checks.

Sample repo to test branch protection behaviour: https://github.com/Financial-Times/next-ivo